### PR TITLE
Fix 404 error on root route for unauthenticated users

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -29,7 +29,12 @@ use App\Http\Controllers\DeductionController;
 use App\Http\Controllers\EvaluateController;
 use App\Http\Controllers\LogisticsUserController;
 use Barryvdh\DomPDF\Facade\Pdf;
+// Root route - redirect to login if not authenticated
 Route::get('/', function () {
+    if (!auth()->check()) {
+        return redirect()->route('login');
+    }
+
     $employees_count = \App\Models\Employee::count();
     $project_count = \App\Models\Project::count();
     $department_count = \App\Models\Department::count();
@@ -37,7 +42,7 @@ Route::get('/', function () {
     $laptop_count = \App\Models\Device::where('device_type', 'Laptop')->count();
     $camera_count = \App\Models\Device::where('device_type', 'Camera')->count();
     return view('index', compact('employees_count', 'project_count', 'department_count', 'routers_count', 'laptop_count', 'camera_count'));
-})->middleware(['auth', 'verified'])->name('dashboard');
+})->middleware(['verified'])->name('dashboard');
 
 Route::get('/import-simcards', function () {
     return view('profile.uploadSimCards');


### PR DESCRIPTION
- Modified root route to check authentication status before loading dashboard
- Unauthenticated users are now redirected to login page instead of getting 404
- Removed 'auth' middleware from root route to allow the redirect to work properly
- Kept 'verified' middleware to ensure email verification for authenticated users

This resolves the issue where accessing the site root while logged out would result in a 404 error.